### PR TITLE
Replace manual session proxy with JDK proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ public class DataConfiguration {
 		return sessionFactoryBean.getObject();
 	}
 
-	@Bean
-	public StatelessSessionProxy statelessSessionProxy(SessionFactory sessionFactory) {
-		return new StatelessSessionProxyImpl(sessionFactory);
-	}
+        @Bean
+        public StatelessSessionProxy statelessSessionProxy(SessionFactory sessionFactory) {
+                return new StatelessSessionProxyImpl(sessionFactory).getProxy();
+        }
 }
 ```
 

--- a/src/main/java/github/gc/demo/DataConfiguration.java
+++ b/src/main/java/github/gc/demo/DataConfiguration.java
@@ -36,8 +36,8 @@ public class DataConfiguration {
 		return sessionFactoryBean.getObject();
 	}
 
-	@Bean
-	public StatelessSessionProxy statelessSessionProxy(SessionFactory sessionFactory) {
-		return new StatelessSessionProxyImpl(sessionFactory);
-	}
+        @Bean
+        public StatelessSessionProxy statelessSessionProxy(SessionFactory sessionFactory) {
+                return new StatelessSessionProxyImpl(sessionFactory).getProxy();
+        }
 }

--- a/src/main/java/github/gc/hibernate/session/proxy/impl/StatelessSessionProxyImpl.java
+++ b/src/main/java/github/gc/hibernate/session/proxy/impl/StatelessSessionProxyImpl.java
@@ -1,625 +1,73 @@
 package github.gc.hibernate.session.proxy.impl;
 
-import github.gc.hibernate.session.StatelessSessionUtils;
 import github.gc.hibernate.session.proxy.StatelessSessionProxy;
-import jakarta.persistence.EntityGraph;
-import jakarta.persistence.TypedQueryReference;
-import jakarta.persistence.criteria.CriteriaDelete;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.CriteriaUpdate;
-import org.hibernate.*;
+import org.hibernate.SessionFactory;
+import org.hibernate.StatelessSession;
 import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.graph.GraphSemantic;
-import org.hibernate.graph.RootGraph;
-import org.hibernate.jdbc.ReturningWork;
-import org.hibernate.jdbc.Work;
-import org.hibernate.procedure.ProcedureCall;
-import org.hibernate.query.MutationQuery;
-import org.hibernate.query.NativeQuery;
-import org.hibernate.query.Query;
-import org.hibernate.query.SelectionQuery;
-import org.hibernate.query.criteria.HibernateCriteriaBuilder;
-import org.hibernate.query.criteria.JpaCriteriaInsert;
-import org.hibernate.query.criteria.JpaCriteriaInsertSelect;
 import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.jdbc.datasource.ConnectionHolder;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 
 import javax.sql.DataSource;
-import java.util.List;
-import java.util.function.Function;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 
 /**
- * 注入到repository的StatelessSession代理
- * 线程安全，事务内使用线程绑定的session，常规操作新建session操作完关闭。
+ * StatelessSession proxy based on JDK dynamic proxies. The actual
+ * {@link StatelessSession} is bound to the current thread for the
+ * duration of a repository method invocation.
  */
-@SuppressWarnings({"deprecation", "unchecked"})
-public class StatelessSessionProxyImpl implements StatelessSessionProxy {
-
-	private final Logger log = LoggerFactory.getLogger(getClass());
-
-	private final SessionFactory sessionFactory;
-	private final DataSource dataSource;
-
-	public StatelessSessionProxyImpl(@NonNull SessionFactory sessionFactory) {
-		Assert.notNull(sessionFactory, "SessionFactory must not be null");
-		this.sessionFactory = sessionFactory;
-		Object datasourceObj = this.sessionFactory.getProperties().get(AvailableSettings.JAKARTA_NON_JTA_DATASOURCE);
-		if (datasourceObj instanceof DataSource ds) {
-			this.dataSource = ds;
-		} else {
-			throw new IllegalArgumentException("SessionFactory must have a DataSource");
-		}
-	}
-
-	@Override
-	public String getTenantIdentifier() {
-		return execute(StatelessSession::getTenantIdentifier);
-	}
-
-	@Override
-	public Object getTenantIdentifierValue() {
-		return execute(StatelessSession::getTenantIdentifierValue);
-	}
-
-	@Override
-	public CacheMode getCacheMode() {
-		return execute(StatelessSession::getCacheMode);
-	}
-
-	@Override
-	public void setCacheMode(CacheMode cacheMode) {
-		execute(session -> {
-			session.setCacheMode(cacheMode);
-			return null;
-		});
-	}
-
-	@Override
-	public void close() {
-		// 不需要关闭
-	}
-
-	@Override
-	public boolean isOpen() {
-		return true;
-	}
-
-	@Override
-	public boolean isConnected() {
-		return false;
-	}
-
-	@Override
-	public Transaction beginTransaction() {
-		throw new UnsupportedOperationException("不允许在StatelessSessionProxy上调用beginTransaction - 使用Spring事务");
-	}
-
-	@Override
-	public Transaction getTransaction() {
-		throw new UnsupportedOperationException("不允许在StatelessSessionProxy上调用getTransaction - 使用Spring事务");
-	}
-
-	@Override
-	public void joinTransaction() {
-		log.debug("自动加入Spring事务，不需要手动调用joinTransaction");
-	}
-
-	@Override
-	public boolean isJoinedToTransaction() {
-		return TransactionSynchronizationManager.isActualTransactionActive();
-	}
-
-	@Override
-	public ProcedureCall getNamedProcedureCall(String name) {
-		throw new UnsupportedOperationException("不支持存储过程调用");
-	}
-
-	@Override
-	public ProcedureCall createStoredProcedureCall(String procedureName) {
-		throw new UnsupportedOperationException("不支持存储过程调用");
-	}
-
-	@Override
-	public ProcedureCall createStoredProcedureCall(String procedureName, Class<?>... resultClasses) {
-		throw new UnsupportedOperationException("不支持存储过程调用");
-	}
-
-	@Override
-	public ProcedureCall createStoredProcedureCall(String procedureName, String... resultSetMappings) {
-		throw new UnsupportedOperationException("不支持存储过程调用");
-	}
-
-	@Override
-	public ProcedureCall createNamedStoredProcedureQuery(String name) {
-		throw new UnsupportedOperationException("不支持存储过程调用");
-	}
-
-	@Override
-	public ProcedureCall createStoredProcedureQuery(String procedureName) {
-		throw new UnsupportedOperationException("不支持存储过程调用");
-	}
-
-	@Override
-	public ProcedureCall createStoredProcedureQuery(String procedureName, Class<?>... resultClasses) {
-		throw new UnsupportedOperationException("不支持存储过程调用");
-	}
-
-	@Override
-	public ProcedureCall createStoredProcedureQuery(String procedureName, String... resultSetMappings) {
-		throw new UnsupportedOperationException("不支持存储过程调用");
-	}
-
-	@Override
-	public Integer getJdbcBatchSize() {
-		return execute(StatelessSession::getJdbcBatchSize);
-	}
-
-	@Override
-	public void setJdbcBatchSize(Integer jdbcBatchSize) {
-		execute(session -> {
-			session.setJdbcBatchSize(jdbcBatchSize);
-			return null;
-		});
-	}
-
-	@Override
-	public HibernateCriteriaBuilder getCriteriaBuilder() {
-		return this.sessionFactory.getCriteriaBuilder();
-	}
-
-	@Override
-	public void doWork(Work work) throws HibernateException {
-		execute(session -> {
-			session.doWork(work);
-			return null;
-		});
-	}
-
-	@Override
-	public <T> T doReturningWork(ReturningWork<T> work) {
-		return execute(session -> session.doReturningWork(work));
-	}
-
-	@Override
-	public <T> RootGraph<T> createEntityGraph(Class<T> rootType) {
-		return execute(session -> session.createEntityGraph(rootType));
-	}
-
-	@Override
-	public RootGraph<?> createEntityGraph(String graphName) {
-		return execute(session -> session.createEntityGraph(graphName));
-	}
-
-	@Override
-	public <T> RootGraph<T> createEntityGraph(Class<T> rootType, String graphName) {
-		return execute(session -> session.createEntityGraph(rootType, graphName));
-	}
-
-	@Override
-	public RootGraph<?> getEntityGraph(String graphName) {
-		return execute(session -> session.getEntityGraph(graphName));
-	}
-
-	@Override
-	public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass) {
-		return execute(session -> session.getEntityGraphs(entityClass));
-	}
-
-	@Override
-	public Filter enableFilter(String filterName) {
-		return execute(session -> session.enableFilter(filterName));
-	}
-
-	@Override
-	public Filter getEnabledFilter(String filterName) {
-		return execute(session -> session.getEnabledFilter(filterName));
-	}
-
-	@Override
-	public void disableFilter(String filterName) {
-		execute(session -> {
-			session.disableFilter(filterName);
-			return null;
-		});
-	}
-
-	@Override
-	public SessionFactory getFactory() {
-		return this.sessionFactory;
-	}
-
-	@Override
-	public Object insert(Object entity) {
-		return execute(session -> session.insert(entity));
-	}
-
-	@Override
-	public void insertMultiple(List<?> entities) {
-		execute(session -> {
-			session.insertMultiple(entities);
-			return null;
-		});
-	}
-
-	@Override
-	public Object insert(String entityName, Object entity) {
-		return execute(session -> session.insert(entityName, entity));
-	}
-
-	@Override
-	public void update(Object entity) {
-		execute(session -> {
-			session.update(entity);
-			return null;
-		});
-	}
-
-	@Override
-	public void updateMultiple(List<?> entities) {
-		execute(session -> {
-			session.updateMultiple(entities);
-			return null;
-		});
-	}
-
-	@Override
-	public void update(String entityName, Object entity) {
-		execute(session -> {
-			session.update(entityName, entity);
-			return null;
-		});
-	}
-
-	@Override
-	public void delete(Object entity) {
-		execute(session -> {
-			session.delete(entity);
-			return null;
-		});
-	}
-
-	@Override
-	public void deleteMultiple(List<?> entities) {
-		execute(session -> {
-			session.deleteMultiple(entities);
-			return null;
-		});
-	}
-
-	@Override
-	public void delete(String entityName, Object entity) {
-		execute(session -> {
-			session.delete(entityName, entity);
-			return null;
-		});
-	}
-
-	@Override
-	public void upsert(Object entity) {
-		execute(session -> {
-			session.upsert(entity);
-			return null;
-		});
-	}
-
-	@Override
-	public void upsertMultiple(List<?> entities) {
-		execute(session -> {
-			session.upsertMultiple(entities);
-			return null;
-		});
-	}
-
-	@Override
-	public void upsert(String entityName, Object entity) {
-		execute(session -> {
-			session.upsert(entityName, entity);
-			return null;
-		});
-	}
-
-	@Override
-	public Object get(String entityName, Object id) {
-		return execute(session -> session.get(entityName, id));
-	}
-
-	@Override
-	public <T> T get(Class<T> entityClass, Object id) {
-		return execute(session -> session.get(entityClass, id));
-	}
-
-	@Override
-	public Object get(String entityName, Object id, LockMode lockMode) {
-		return execute(session -> session.get(entityName, id, lockMode));
-	}
-
-	@Override
-	public <T> T get(Class<T> entityClass, Object id, LockMode lockMode) {
-		return execute(session -> session.get(entityClass, id, lockMode));
-	}
-
-	@Override
-	public <T> T get(EntityGraph<T> graph, GraphSemantic graphSemantic, Object id) {
-		return execute(session -> session.get(graph, graphSemantic, id));
-	}
-
-	@Override
-	public <T> T get(EntityGraph<T> graph, GraphSemantic graphSemantic, Object id, LockMode lockMode) {
-		return execute(session -> session.get(graph, graphSemantic, id, lockMode));
-	}
-
-	@Override
-	public <T> List<T> getMultiple(Class<T> entityClass, List<Object> ids) {
-		return execute(session -> session.getMultiple(entityClass, ids));
-	}
-
-	@Override
-	public void refresh(Object entity) {
-		execute(session -> {
-			session.refresh(entity);
-			return null;
-		});
-	}
-
-	@Override
-	public void refresh(String entityName, Object entity) {
-		execute(session -> {
-			session.refresh(entityName, entity);
-			return null;
-		});
-	}
-
-	@Override
-	public void refresh(Object entity, LockMode lockMode) {
-		execute(session -> {
-			session.refresh(entity, lockMode);
-			return null;
-		});
-	}
-
-	@Override
-	public void refresh(String entityName, Object entity, LockMode lockMode) {
-		execute(session -> {
-			session.refresh(entityName, entity, lockMode);
-			return null;
-		});
-	}
-
-	@Override
-	public void fetch(Object association) {
-		execute(session -> {
-			session.fetch(association);
-			return null;
-		});
-	}
-
-	@Override
-	public Object getIdentifier(Object entity) {
-		return execute(session -> session.getIdentifier(entity));
-	}
-
-	@Override
-	public Query<?> createQuery(String queryString) {
-		return execute(session -> session.createQuery(queryString));
-	}
-
-	@Override
-	public <R> Query<R> createQuery(String queryString, Class<R> resultClass) {
-		return execute(session -> session.createQuery(queryString, resultClass));
-	}
-
-	@Override
-	public <R> Query<R> createQuery(TypedQueryReference<R> typedQueryReference) {
-		return execute(session -> session.createQuery(typedQueryReference));
-	}
-
-	@Override
-	public <R> Query<R> createQuery(CriteriaQuery<R> criteriaQuery) {
-		return execute(session -> session.createQuery(criteriaQuery));
-	}
-
-	@Override
-	public Query<?> createQuery(CriteriaUpdate<?> updateQuery) {
-		return execute(session -> session.createQuery(updateQuery));
-	}
-
-	@Override
-	public Query<?> createQuery(CriteriaDelete<?> deleteQuery) {
-		return execute(session -> session.createQuery(deleteQuery));
-	}
-
-	@Override
-	public NativeQuery<?> createNativeQuery(String sqlString) {
-		return execute(session -> session.createNativeQuery(sqlString));
-	}
-
-	@Override
-	public <R> NativeQuery<R> createNativeQuery(String sqlString, Class<R> resultClass) {
-		return execute(session -> session.createNativeQuery(sqlString, resultClass));
-	}
-
-	@Override
-	public <R> NativeQuery<R> createNativeQuery(String sqlString, Class<R> resultClass, String tableAlias) {
-		return execute(session -> session.createNativeQuery(sqlString, resultClass, tableAlias));
-	}
-
-	@Override
-	public NativeQuery<?> createNativeQuery(String sqlString, String resultSetMappingName) {
-		return execute(session -> session.createNativeQuery(sqlString, resultSetMappingName));
-	}
-
-	@Override
-	public <R> NativeQuery<R> createNativeQuery(String sqlString, String resultSetMappingName, Class<R> resultClass) {
-		return execute(session -> session.createNativeQuery(sqlString, resultSetMappingName, resultClass));
-	}
-
-	@Override
-	public SelectionQuery<?> createSelectionQuery(String hqlString) {
-		return execute(session -> session.createSelectionQuery(hqlString));
-	}
-
-	@Override
-	public <R> SelectionQuery<R> createSelectionQuery(String hqlString, Class<R> resultType) {
-		return execute(session -> session.createSelectionQuery(hqlString, resultType));
-	}
-
-	@Override
-	public <R> SelectionQuery<R> createSelectionQuery(CriteriaQuery<R> criteria) {
-		return execute(session -> session.createSelectionQuery(criteria));
-	}
-
-	@Override
-	public MutationQuery createMutationQuery(String hqlString) {
-		return execute(session -> session.createMutationQuery(hqlString));
-	}
-
-	@Override
-	public MutationQuery createMutationQuery(CriteriaUpdate<?> updateQuery) {
-		return execute(session -> session.createMutationQuery(updateQuery));
-	}
-
-	@Override
-	public MutationQuery createMutationQuery(CriteriaDelete<?> deleteQuery) {
-		return execute(session -> session.createMutationQuery(deleteQuery));
-	}
-
-	@Override
-	public MutationQuery createMutationQuery(JpaCriteriaInsertSelect<?> insertSelect) {
-		return execute(session -> session.createMutationQuery(insertSelect));
-	}
-
-	@Override
-	public MutationQuery createMutationQuery(JpaCriteriaInsert<?> insert) {
-		return execute(session -> session.createMutationQuery(insert));
-	}
-
-	@Override
-	public MutationQuery createNativeMutationQuery(String sqlString) {
-		return execute(session -> session.createNativeMutationQuery(sqlString));
-	}
-
-	@Override
-	public Query<?> createNamedQuery(String name) {
-		return execute(session -> session.createNamedQuery(name));
-	}
-
-	@Override
-	public <R> Query<R> createNamedQuery(String name, Class<R> resultClass) {
-		return execute(session -> session.createNamedQuery(name, resultClass));
-	}
-
-	@Override
-	public SelectionQuery<?> createNamedSelectionQuery(String name) {
-		return execute(session -> session.createNamedSelectionQuery(name));
-	}
-
-	@Override
-	public <R> SelectionQuery<R> createNamedSelectionQuery(String name, Class<R> resultType) {
-		return execute(session -> session.createNamedSelectionQuery(name, resultType));
-	}
-
-	@Override
-	public MutationQuery createNamedMutationQuery(String name) {
-		return execute(session -> session.createNamedMutationQuery(name));
-	}
-
-	@Override
-	public Query<?> getNamedQuery(String queryName) {
-		return execute(session -> session.getNamedQuery(queryName));
-	}
-
-	@Override
-	public NativeQuery<?> getNamedNativeQuery(String name) {
-		return execute(session -> session.getNamedNativeQuery(name));
-	}
-
-	@Override
-	public NativeQuery<?> getNamedNativeQuery(String name, String resultSetMapping) {
-		return execute(session -> session.getNamedNativeQuery(name, resultSetMapping));
-	}
-
-	@Nullable
-	@Override
-	public StatelessSession getCurrentSession() {
-		return StatelessSessionUtils.doGetTransactionalStatelessSession(sessionFactory, dataSource);
-	}
-
-	@Override
-	public String toString() {
-		return "StatelessSession proxy for sessionFactory [%s]".formatted(this.sessionFactory);
-	}
-
-	private <R> R execute(Function<StatelessSession, R> function) {
-		StatelessSession session = StatelessSessionUtils.doGetTransactionalStatelessSession(sessionFactory, dataSource);
-		boolean isNewSs = false;
-		if (session == null) {
-			session = sessionFactory.openStatelessSession();
-			isNewSs = true;
-		}
-
-		try {
-			R result = function.apply(session);
-			if (result instanceof NativeQuery<?> nativeQuery) {
-				if (isNewSs) {
-					result = ((R) new NativeQueryProxy<>(nativeQuery, session));
-					isNewSs = false;
-				} else {
-					applyTransactionTimeout(result);
-				}
-
-			} else if (result instanceof Query<?> query) {
-				if (isNewSs) {
-					result = ((R) new QueryProxy<>(query, session));
-					isNewSs = false;
-				} else {
-					applyTransactionTimeout(result);
-				}
-			} else if (result instanceof SelectionQuery<?> selectionQuery) {
-				if (isNewSs) {
-					result = ((R) new SelectionQueryProxy<>(selectionQuery, session));
-					isNewSs = false;
-				} else {
-					applyTransactionTimeout(result);
-				}
-			} else if (result instanceof MutationQuery mutationQuery) {
-				if (isNewSs) {
-					result = ((R) new MutationQueryProxy(mutationQuery, session));
-					isNewSs = false;
-				} else {
-					applyTransactionTimeout(result);
-				}
-			}
-
-			return result;
-		} finally {
-			if (isNewSs) {
-				StatelessSessionUtils.closeStatelessSession(session);
-			}
-		}
-	}
-
-	private <R> void applyTransactionTimeout(R query) {
-		ConnectionHolder connHolder = (ConnectionHolder) TransactionSynchronizationManager.getResource(dataSource);
-		if (connHolder != null && connHolder.hasTimeout()) {
-			int timeoutValue = connHolder.getTimeToLiveInSeconds();
-			try {
-				if (query instanceof NativeQuery<?> nativeQuery) {
-					nativeQuery.setTimeout(timeoutValue);
-				} else if (query instanceof Query<?> q) {
-					q.setTimeout(timeoutValue);
-				} else if (query instanceof SelectionQuery<?> selectionQuery) {
-					selectionQuery.setTimeout(timeoutValue);
-				} else if (query instanceof MutationQuery mutationQuery) {
-					mutationQuery.setTimeout(timeoutValue);
-				}
-			} catch (IllegalArgumentException ex) {
-				// oh well, at least we tried...
-			}
-		}
-	}
+public class StatelessSessionProxyImpl implements InvocationHandler {
+
+    private static final ThreadLocal<StatelessSession> SESSION_HOLDER = new ThreadLocal<>();
+
+    private final SessionFactory sessionFactory;
+    private final DataSource dataSource;
+    private final StatelessSessionProxy proxy;
+
+    public StatelessSessionProxyImpl(@NonNull SessionFactory sessionFactory) {
+        Assert.notNull(sessionFactory, "SessionFactory must not be null");
+        this.sessionFactory = sessionFactory;
+        Object dsObj = sessionFactory.getProperties().get(AvailableSettings.JAKARTA_NON_JTA_DATASOURCE);
+        if (dsObj instanceof DataSource ds) {
+            this.dataSource = ds;
+        } else {
+            throw new IllegalArgumentException("SessionFactory must have a DataSource");
+        }
+        this.proxy = (StatelessSessionProxy) Proxy.newProxyInstance(
+                StatelessSessionProxy.class.getClassLoader(),
+                new Class<?>[]{StatelessSessionProxy.class}, this);
+    }
+
+    public StatelessSessionProxy getProxy() {
+        return this.proxy;
+    }
+
+    SessionFactory getSessionFactory() {
+        return this.sessionFactory;
+    }
+
+    DataSource getDataSource() {
+        return this.dataSource;
+    }
+
+    void bind(StatelessSession session) {
+        SESSION_HOLDER.set(session);
+    }
+
+    void unbind() {
+        SESSION_HOLDER.remove();
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if ("getCurrentSession".equals(method.getName()) && method.getParameterCount() == 0) {
+            return SESSION_HOLDER.get();
+        }
+        StatelessSession session = SESSION_HOLDER.get();
+        if (session == null) {
+            throw new IllegalStateException("No StatelessSession bound to current thread");
+        }
+        return method.invoke(session, args);
+    }
 }

--- a/src/main/java/github/gc/jakartadata/repository/RepositoryUtils.java
+++ b/src/main/java/github/gc/jakartadata/repository/RepositoryUtils.java
@@ -1,11 +1,16 @@
 package github.gc.jakartadata.repository;
 
 import github.gc.hibernate.session.proxy.StatelessSessionProxy;
+import github.gc.hibernate.session.proxy.impl.StatelessSessionProxyImpl;
+import github.gc.hibernate.session.StatelessSessionUtils;
 import org.hibernate.StatelessSession;
 import org.jspecify.annotations.NonNull;
 import org.springframework.util.Assert;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -17,21 +22,29 @@ public final class RepositoryUtils {
 
 	private static final Map<Class<?>, Class<?>> repositoryImplClasses = new ConcurrentHashMap<>(64);
 
-	@NonNull
-	public static <R> R createRepository(@NonNull Class<R> repositoryInterfaceClass,
-			@NonNull StatelessSessionProxy sessionProxy) {
-		Assert.notNull(repositoryInterfaceClass, "repositoryInterfaceClass must not be null");
-		Assert.notNull(sessionProxy, "sessionProxy must not be null");
+    @NonNull
+    public static <R> R createRepository(@NonNull Class<R> repositoryInterfaceClass,
+                    @NonNull StatelessSessionProxy sessionProxy) {
+        Assert.notNull(repositoryInterfaceClass, "repositoryInterfaceClass must not be null");
+        Assert.notNull(sessionProxy, "sessionProxy must not be null");
 
-		Class<R> repositoryImplClass = getRepositoryImplClass(repositoryInterfaceClass);
+        Class<R> repositoryImplClass = getRepositoryImplClass(repositoryInterfaceClass);
 
-		try {
-			Constructor<R> constructor = repositoryImplClass.getConstructor(StatelessSession.class);
-			return constructor.newInstance(sessionProxy);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
+        try {
+            Constructor<R> constructor = repositoryImplClass.getConstructor(StatelessSession.class);
+            R target = constructor.newInstance(sessionProxy);
+
+            StatelessSessionProxyImpl handler =
+                    (StatelessSessionProxyImpl) Proxy.getInvocationHandler(sessionProxy);
+
+            InvocationHandler repoHandler = new RepositoryInvocationHandler<>(target, handler);
+
+            return (R) Proxy.newProxyInstance(repositoryInterfaceClass.getClassLoader(),
+                    new Class<?>[]{repositoryInterfaceClass}, repoHandler);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
 	public static <R, I extends R> Class<I> getRepositoryImplClass(@NonNull Class<R> repositoryInterface) {
 		Assert.notNull(repositoryInterface, "repositoryInterface must not be null");
@@ -40,14 +53,46 @@ public final class RepositoryUtils {
 				RepositoryUtils::doGetRepositoryImplClass);
 	}
 
-	private static Class<?> doGetRepositoryImplClass(Class<?> repositoryInterface) {
-		String interfaceName = repositoryInterface.getName();
-		// hibernate-processor生成的Repository实现类
-		String implName = interfaceName + "_";
-		try {
-			return Class.forName(implName);
-		} catch (Exception e) {
-			throw new RuntimeException("加载Jakarta Data Repository实现类[%s]失败".formatted(implName), e);
-		}
-	}
+        private static Class<?> doGetRepositoryImplClass(Class<?> repositoryInterface) {
+                String interfaceName = repositoryInterface.getName();
+                // hibernate-processor生成的Repository实现类
+                String implName = interfaceName + "_";
+                try {
+                        return Class.forName(implName);
+                } catch (Exception e) {
+                        throw new RuntimeException("加载Jakarta Data Repository实现类[%s]失败".formatted(implName), e);
+                }
+        }
+
+        private static class RepositoryInvocationHandler<T> implements InvocationHandler {
+                private final T target;
+                private final StatelessSessionProxyImpl sessionHandler;
+
+                RepositoryInvocationHandler(T target, StatelessSessionProxyImpl sessionHandler) {
+                        this.target = target;
+                        this.sessionHandler = sessionHandler;
+                }
+
+                @Override
+                public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                        var sf = sessionHandler.getSessionFactory();
+                        var ds = sessionHandler.getDataSource();
+                        StatelessSession session = StatelessSessionUtils.doGetTransactionalStatelessSession(sf, ds);
+                        boolean isNew = false;
+                        if (session == null) {
+                                session = sf.openStatelessSession();
+                                isNew = true;
+                        }
+
+                        sessionHandler.bind(session);
+                        try {
+                                return method.invoke(target, args);
+                        } finally {
+                                sessionHandler.unbind();
+                                if (isNew) {
+                                        StatelessSessionUtils.closeStatelessSession(session);
+                                }
+                        }
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- simplify StatelessSessionProxyImpl using a JDK dynamic proxy
- wrap repositories in a dynamic proxy so each method uses a single StatelessSession
- adjust demo configuration and README for new proxy API
- refine repository invocation handler generics

## Testing
- `mvn -q -DskipTests package` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685372aae378832991f22990214fcac6