### PR TITLE
Fix session proxy resource handling and typos

### DIFF
--- a/src/main/java/github/gc/demo/DataConfiguration.java
+++ b/src/main/java/github/gc/demo/DataConfiguration.java
@@ -22,7 +22,7 @@ public class DataConfiguration {
 	public SessionFactory sessionFactory(DataSource dataSource) {
 		SessionFactoryBean sessionFactoryBean = new SessionFactoryBean();
 		sessionFactoryBean.setDataSource(dataSource);
-		sessionFactoryBean.setPackagesToScanEntity(new String[]{"github.gc.**.model"});
+                sessionFactoryBean.setPackagesToScan(new String[]{"github.gc.**.model"});
 		Properties properties = sessionFactoryBean.getHibernateProperties();
 		properties.put(AvailableSettings.SHOW_SQL, Boolean.FALSE);
 		properties.put(AvailableSettings.FORMAT_SQL, Boolean.TRUE);

--- a/src/main/java/github/gc/demo/repository/TestRepository.java
+++ b/src/main/java/github/gc/demo/repository/TestRepository.java
@@ -22,7 +22,7 @@ public interface TestRepository extends CrudRepository<TestModel, Long> {
 	@OrderBy(_TestModel.ID)
 	List<TestModel> byIdRange(Range<Long> id);
 
-	record ByNameDto(Long primaryId,String modelMame){}
+        record ByNameDto(Long primaryId, String modelName){}
 
 	@Query(" select id, name from TestModel order by id asc ")
 	List<ByNameDto> dTobyName();

--- a/src/main/java/github/gc/hibernate/factory/SessionFactoryBean.java
+++ b/src/main/java/github/gc/hibernate/factory/SessionFactoryBean.java
@@ -85,7 +85,7 @@ public class SessionFactoryBean implements FactoryBean<SessionFactory>, Initiali
 		this.hibernateProperties = hibernateProperties;
 	}
 
-	public void setPackagesToScanEntity(String[] packagesToScan) {
-		this.packagesToScan = packagesToScan;
-	}
+        public void setPackagesToScan(String[] packagesToScan) {
+                this.packagesToScan = packagesToScan;
+        }
 }

--- a/src/main/java/github/gc/hibernate/session/proxy/QueryProxySupport.java
+++ b/src/main/java/github/gc/hibernate/session/proxy/QueryProxySupport.java
@@ -3,6 +3,7 @@ package github.gc.hibernate.session.proxy;
 import github.gc.hibernate.session.StatelessSessionUtils;
 import org.hibernate.StatelessSession;
 import org.jspecify.annotations.NonNull;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 
 import java.util.function.Supplier;
@@ -16,11 +17,14 @@ public abstract class QueryProxySupport {
 		this.session = session;
 	}
 
-	protected <T> T execute(Supplier<T> supplier) {
-		try {
-			return supplier.get();
-		} finally {
-			StatelessSessionUtils.closeStatelessSession(this.session);
-		}
-	}
+        protected <T> T execute(Supplier<T> supplier) {
+                boolean transactional = TransactionSynchronizationManager.hasResource(this.session.getSessionFactory());
+                try {
+                        return supplier.get();
+                } finally {
+                        if (!transactional) {
+                                StatelessSessionUtils.closeStatelessSession(this.session);
+                        }
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- avoid closing stateless session when it is transaction-managed
- rename `setPackagesToScanEntity` to `setPackagesToScan`
- update demo configuration to use new method
- fix typo in `ByNameDto` record

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853799771808329acd5bdcc3f353c24